### PR TITLE
Use unqualified min and max for array conversion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 project(NcorrGUI CXX)
 
 # --- Basic Qt Setup ---
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -45,9 +45,12 @@ cv::Mat MainWindow::array2d_to_cvmat(const ncorr::Array2D<double>& array)
         return cv::Mat();
     }
 
+    using ncorr::min;
+    using ncorr::max;
+
     cv::Mat mat(array.height(), array.width(), CV_8UC1);
-    double min_val = ncorr::min(array); // Correctly called on a double array
-    double max_val = ncorr::max(array); // Correctly called on a double array
+    double min_val = min(array); // Correctly called on a double array
+    double max_val = max(array); // Correctly called on a double array
     double scale = 255.0;
     if (max_val > min_val) {
         scale = 255.0 / (max_val - min_val);
@@ -232,7 +235,7 @@ void MainWindow::plot_data(const ncorr::Data2D& data_to_plot, const QString& win
     }
     // Using namedWindow to avoid conflicts with other windows
     cv::destroyWindow(window_title.toStdString());
-    ncorr::imshow(data_to_plot);
+    imshow(data_to_plot);
     cv::setWindowTitle(window_title.toStdString(), window_title.toStdString());
 }
 


### PR DESCRIPTION
## Summary
- Use `min`/`max` via using declarations in `array2d_to_cvmat`
- Call `imshow` via argument-dependent lookup in `plot_data`
- Build with C++14 to enable modern utilities

## Testing
- `cmake -S . -B build -DCMAKE_CXX_FLAGS=-fpermissive`
- `cmake --build build` *(fails: missing `opencv_core300` and other libraries)*


------
https://chatgpt.com/codex/tasks/task_e_68915d59680c8320a18970ca1b2c51eb