### PR TITLE
Suppress MSVC checked iterator warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,4 +83,5 @@ add_custom_command(TARGET NcorrGUI POST_BUILD
 # --- Suppress specific MSVC warnings ---
 if(MSVC)
     target_compile_options(NcorrGUI PRIVATE /wd4267 /wd4244)
+    target_compile_definitions(NcorrGUI PRIVATE _SCL_SECURE_NO_WARNINGS)
 endif()


### PR DESCRIPTION
## Summary
- Define `_SCL_SECURE_NO_WARNINGS` for MSVC builds to silence checked iterator warnings from `std::copy` and `std::uninitialized_copy_n`.

## Testing
- `cmake -S . -B build -DCMAKE_CXX_FLAGS=-fpermissive`
- `cmake --build build` *(fails: no matching function for call to `ncorr::min`, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689160dd0e6483208cf6b676b31ad894