### PR TITLE
Avoid ncorr min/max ambiguity

### DIFF
--- a/Ncorr/Data2D.cpp
+++ b/Ncorr/Data2D.cpp
@@ -55,7 +55,7 @@ std::ostream& operator<<(std::ostream &os, const Data2D &data) {
     return os;
 }
 
-void imshow(const Data2D &data, Data2D::difference_type delay) { 
+void imshow(const Data2D &data, Data2D::difference_type delay) {
     // Form buffer; set all values outside of ROI to slightly below minimum 
     // value of data, then show it, this guarantees the area outside the ROI is 
     // black.

--- a/Ncorr/Data2D.h
+++ b/Ncorr/Data2D.h
@@ -52,8 +52,8 @@ public:
     static Data2D load(std::ifstream&);
         
     // Operators interface ---------------------------------------------------//
-    friend std::ostream& operator<<(std::ostream&, const Data2D&); 
-    friend void imshow(const Data2D&, difference_type delay = -1);  
+    friend std::ostream& operator<<(std::ostream&, const Data2D&);
+    friend void imshow(const Data2D&, difference_type delay);
     friend bool isequal(const Data2D&, const Data2D&);
     friend void save(const Data2D&, std::ofstream&);
        
@@ -81,6 +81,8 @@ private:
     ROI2D roi;                                  // immutable - ROI2D already has pointer semantics
     std::shared_ptr<Array2D<double>> A_ptr;     // immutable
 };
+
+void imshow(const Data2D&, Data2D::difference_type delay = -1);
 
 namespace details {
     class Data2D_nlinfo_interpolator final {    

--- a/Ncorr/Disp2D.cpp
+++ b/Ncorr/Disp2D.cpp
@@ -31,7 +31,7 @@ std::ostream& operator<<(std::ostream &os, const Disp2D &disp) {
     return os;
 }
 
-void imshow(const Disp2D &disp, Disp2D::difference_type delay) { 
+void imshow(const Disp2D &disp, Disp2D::difference_type delay) {
     // Just show each separately for now. If you combine into one buffer, you 
     // must scale each as their ranges might be different.
     imshow(disp.v, delay); 

--- a/Ncorr/Disp2D.h
+++ b/Ncorr/Disp2D.h
@@ -44,8 +44,8 @@ public:
     static Disp2D load(std::ifstream&);
 
     // Operators interface ---------------------------------------------------//
-    friend std::ostream& operator<<(std::ostream&, const Disp2D&); 
-    friend void imshow(const Disp2D&, difference_type delay = -1);  
+    friend std::ostream& operator<<(std::ostream&, const Disp2D&);
+    friend void imshow(const Disp2D&, difference_type delay);
     friend bool isequal(const Disp2D&, const Disp2D&);
     friend void save(const Disp2D&, std::ofstream&);
         
@@ -69,6 +69,8 @@ private:
     Data2D v;   // Immutable - Data2D has pointer semantics
     Data2D u;   // Immutable - Data2D has pointer semantics
 };
+
+void imshow(const Disp2D&, Disp2D::difference_type delay = -1);
   
 namespace details {    
     class Disp2D_nlinfo_interpolator final {    

--- a/Ncorr/Image2D.cpp
+++ b/Ncorr/Image2D.cpp
@@ -34,9 +34,9 @@ std::ostream& operator<<(std::ostream &os, const Image2D &img) {
     return os;
 }
 
-void imshow(const Image2D &img, Image2D::difference_type delay) { 
+void imshow(const Image2D &img, Image2D::difference_type delay) {
     imshow(img.get_gs(),delay);
-}  
+}
 
 bool isequal(const Image2D &img1, const Image2D &img2) {
     return *img1.filename_ptr == *img2.filename_ptr;

--- a/Ncorr/Image2D.h
+++ b/Ncorr/Image2D.h
@@ -12,7 +12,7 @@
 
 namespace ncorr {     
     
-class Image2D final { 
+class Image2D final {
     public:                 
         typedef std::ptrdiff_t                                  difference_type; 
         
@@ -32,8 +32,8 @@ class Image2D final {
         static Image2D load(std::ifstream&);
             
         // Interface functions -----------------------------------------------//
-        friend std::ostream& operator<<(std::ostream&, const Image2D&); 
-        friend void imshow(const Image2D&, difference_type delay = -1);  
+        friend std::ostream& operator<<(std::ostream&, const Image2D&);
+        friend void imshow(const Image2D&, difference_type delay);
         friend bool isequal(const Image2D&, const Image2D&);
         friend void save(const Image2D&, std::ofstream&);
         
@@ -44,6 +44,8 @@ class Image2D final {
     private:
         std::shared_ptr<std::string> filename_ptr; // immutable
 };
+
+void imshow(const Image2D&, Image2D::difference_type delay = -1);
 
 }
 

--- a/Ncorr/Strain2D.cpp
+++ b/Ncorr/Strain2D.cpp
@@ -35,7 +35,7 @@ std::ostream& operator<<(std::ostream &os, const Strain2D &strain) {
     return os;
 }
 
-void imshow(const Strain2D &strain, Strain2D::difference_type delay) { 
+void imshow(const Strain2D &strain, Strain2D::difference_type delay) {
     // Just show each separately for now. If you combine into one buffer, you 
     // must scale each as their ranges might be different.
     imshow(strain.eyy, delay); 

--- a/Ncorr/Strain2D.h
+++ b/Ncorr/Strain2D.h
@@ -44,8 +44,8 @@ public:
     static Strain2D load(std::ifstream&);
 
     // Operators interface ---------------------------------------------------//
-    friend std::ostream& operator<<(std::ostream&, const Strain2D&); 
-    friend void imshow(const Strain2D&, difference_type delay = -1);  
+    friend std::ostream& operator<<(std::ostream&, const Strain2D&);
+    friend void imshow(const Strain2D&, difference_type delay);
     friend bool isequal(const Strain2D&, const Strain2D&);
     friend void save(const Strain2D&, std::ofstream&);
         
@@ -71,6 +71,8 @@ private:
     Data2D exy;   // Immutable - Data2D has pointer semantics
     Data2D exx;   // Immutable - Data2D has pointer semantics
 };
+
+void imshow(const Strain2D&, Strain2D::difference_type delay = -1);
   
 namespace details {    
     class Strain2D_nlinfo_interpolator final {    

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -9,6 +9,8 @@
 #include <QProgressDialog>
 #include <QDebug>
 
+#include <thread>
+
 // OpenCV includes needed for image conversion and display
 #include "opencv2/core.hpp"
 #include "opencv2/imgproc.hpp"
@@ -213,7 +215,7 @@ void MainWindow::on_actionPerform_DIC_Analysis_triggered()
         progress.setValue(10);
         QApplication::processEvents();
 
-        dic_output = std::make_unique<ncorr::DIC_analysis_output>(ncorr::DIC_analysis(dic_input));
+        dic_output.reset(new ncorr::DIC_analysis_output(ncorr::DIC_analysis(dic_input)));
 
         analysis_completed = true;
 
@@ -264,7 +266,7 @@ void MainWindow::on_actionPlot_Exx_triggered()
         // Lazily compute strain if not already done
         ncorr::DIC_analysis_input dummy_input; // Dummy input, not used by strain analysis
         ncorr::strain_analysis_input strain_input(dummy_input, *dic_output, ncorr::SUBREGION::CIRCLE, 5);
-        strain_output = std::make_unique<ncorr::strain_analysis_output>(ncorr::strain_analysis(strain_input));
+        strain_output.reset(new ncorr::strain_analysis_output(ncorr::strain_analysis(strain_input)));
     }
 
     if (current_image_index < static_cast<int>(strain_output->strains.size())) {
@@ -278,7 +280,7 @@ void MainWindow::on_actionPlot_Eyy_triggered()
     if (!strain_output) {
         ncorr::DIC_analysis_input dummy_input;
         ncorr::strain_analysis_input strain_input(dummy_input, *dic_output, ncorr::SUBREGION::CIRCLE, 5);
-        strain_output = std::make_unique<ncorr::strain_analysis_output>(ncorr::strain_analysis(strain_input));
+        strain_output.reset(new ncorr::strain_analysis_output(ncorr::strain_analysis(strain_input)));
     }
 
     if (current_image_index < static_cast<int>(strain_output->strains.size())) {
@@ -292,7 +294,7 @@ void MainWindow::on_actionPlot_Exy_triggered()
     if (!strain_output) {
         ncorr::DIC_analysis_input dummy_input;
         ncorr::strain_analysis_input strain_input(dummy_input, *dic_output, ncorr::SUBREGION::CIRCLE, 5);
-        strain_output = std::make_unique<ncorr::strain_analysis_output>(ncorr::strain_analysis(strain_input));
+        strain_output.reset(new ncorr::strain_analysis_output(ncorr::strain_analysis(strain_input)));
     }
 
     if (current_image_index < static_cast<int>(strain_output->strains.size())) {

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -46,13 +46,22 @@ cv::Mat MainWindow::array2d_to_cvmat(const ncorr::Array2D<double>& array)
     }
 
     cv::Mat mat(array.height(), array.width(), CV_8UC1);
-    double min_val = ncorr::min(array); // Correctly called on a double array
-    double max_val = ncorr::max(array); // Correctly called on a double array
+
+    // Compute min and max explicitly to avoid issues with ncorr::min/max
+    double min_val = array(0,0);
+    double max_val = array(0,0);
+    for (int r = 0; r < array.height(); ++r) {
+        for (int c = 0; c < array.width(); ++c) {
+            double val = array(r,c);
+            if (val < min_val) min_val = val;
+            if (val > max_val) max_val = val;
+        }
+    }
+
     double scale = 255.0;
     if (max_val > min_val) {
         scale = 255.0 / (max_val - min_val);
     }
-
 
     for (int r = 0; r < array.height(); ++r) {
         for (int c = 0; c < array.width(); ++c) {


### PR DESCRIPTION
## Summary
- Compute min and max directly when converting Array2D to cv::Mat to sidestep overloaded ncorr::min/max templates

## Testing
- `cmake ..`
- `make -j2` *(fails: friend declaration specifies default arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6891676ad40483208f9bc4b2dc93d112