### PR TITLE
Avoid Ncorr min/max in GUI image conversion

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -39,7 +39,9 @@ MainWindow::~MainWindow()
 //----------------------------------------------------------------//
 
 // This function correctly converts Ncorr's custom array to an OpenCV Mat
-cv::Mat MainWindow::array2d_to_cvmat(const ncorr::Array2D<double>& array)
+// and works with any numeric element type.
+template <typename T>
+cv::Mat MainWindow::array2d_to_cvmat(const ncorr::Array2D<T>& array)
 {
     // The min/max helpers in ncorr require two arguments for ROI-aware
     // searches and break when `Array2D<bool>` is supplied.  Compute the
@@ -51,18 +53,19 @@ cv::Mat MainWindow::array2d_to_cvmat(const ncorr::Array2D<double>& array)
     cv::Mat mat(array.height(), array.width(), CV_8UC1);
 
     auto minmax = std::minmax_element(array.cbegin(), array.cend());
-    double min_val = *minmax.first;
-    double max_val = *minmax.second;
+    T min_val = *minmax.first;
+    T max_val = *minmax.second;
 
     double scale = 255.0;
     if (max_val > min_val) {
-        scale = 255.0 / (max_val - min_val);
+        scale = 255.0 /
+                static_cast<double>(max_val - min_val);
     }
 
     for (int r = 0; r < array.height(); ++r) {
         for (int c = 0; c < array.width(); ++c) {
-            mat.at<uchar>(r, c) =
-                static_cast<uchar>((array(r, c) - min_val) * scale);
+            mat.at<uchar>(r, c) = static_cast<uchar>(
+                static_cast<double>(array(r, c) - min_val) * scale);
         }
     }
     return mat;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -10,6 +10,7 @@
 #include <QDebug>
 
 #include <thread>
+#include <algorithm>
 
 // OpenCV includes needed for image conversion and display
 #include "opencv2/core.hpp"
@@ -40,25 +41,20 @@ MainWindow::~MainWindow()
 // This function correctly converts Ncorr's custom array to an OpenCV Mat
 cv::Mat MainWindow::array2d_to_cvmat(const ncorr::Array2D<double>& array)
 {
-    // The min/max functions in Ncorr are defined for arithmetic types, not bool.
-    // The error occurs because you might be calling this on a mask.
-    // This corrected version assumes the input 'array' is the data you want to visualize.
+    // The min/max helpers in ncorr require two arguments for ROI-aware
+    // searches and break when `Array2D<bool>` is supplied.  Compute the
+    // minimum and maximum directly to keep this routine generic.
     if (array.empty()) {
         return cv::Mat();
     }
 
     cv::Mat mat(array.height(), array.width(), CV_8UC1);
 
-    // Compute min and max explicitly to avoid issues with ncorr::min/max
-    double min_val = array(0,0);
-    double max_val = array(0,0);
-    for (int r = 0; r < array.height(); ++r) {
-        for (int c = 0; c < array.width(); ++c) {
-            double val = array(r,c);
-            if (val < min_val) min_val = val;
-            if (val > max_val) max_val = val;
-        }
-    }
+    const double *begin = array.get_pointer();
+    const double *end   = begin + array.size();
+    auto minmax = std::minmax_element(begin, end);
+    double min_val = *minmax.first;
+    double max_val = *minmax.second;
 
     double scale = 255.0;
     if (max_val > min_val) {
@@ -67,7 +63,8 @@ cv::Mat MainWindow::array2d_to_cvmat(const ncorr::Array2D<double>& array)
 
     for (int r = 0; r < array.height(); ++r) {
         for (int c = 0; c < array.width(); ++c) {
-            mat.at<uchar>(r, c) = static_cast<uchar>((array(r, c) - min_val) * scale);
+            mat.at<uchar>(r, c) =
+                static_cast<uchar>((array(r, c) - min_val) * scale);
         }
     }
     return mat;

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -43,9 +43,9 @@ MainWindow::~MainWindow()
 template <typename T>
 cv::Mat MainWindow::array2d_to_cvmat(const ncorr::Array2D<T>& array)
 {
-    // The min/max helpers in ncorr require two arguments for ROI-aware
-    // searches and break when `Array2D<bool>` is supplied.  Compute the
-    // minimum and maximum directly to keep this routine generic.
+    // Ncorr's ROI-aware min/max helpers expect two arguments and fail on
+    // boolean arrays.  Use std::minmax_element to compute the intensity
+    // bounds directly so this routine works for any numeric Array2D.
     if (array.empty()) {
         return cv::Mat();
     }

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -50,9 +50,7 @@ cv::Mat MainWindow::array2d_to_cvmat(const ncorr::Array2D<double>& array)
 
     cv::Mat mat(array.height(), array.width(), CV_8UC1);
 
-    const double *begin = array.get_pointer();
-    const double *end   = begin + array.size();
-    auto minmax = std::minmax_element(begin, end);
+    auto minmax = std::minmax_element(array.cbegin(), array.cend());
     double min_val = *minmax.first;
     double max_val = *minmax.second;
 

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -78,7 +78,8 @@ private:
     void update_image_displays();
     void update_status_labels();
     void plot_data(const ncorr::Data2D& data_to_plot, const QString& window_title);
-    cv::Mat array2d_to_cvmat(const ncorr::Array2D<double>& array);
+    template <typename T>
+    cv::Mat array2d_to_cvmat(const ncorr::Array2D<T>& array);
     QPixmap mat_to_qpixmap(const cv::Mat& mat);
 };
 


### PR DESCRIPTION
## Summary
- compute Array2D image bounds using `std::minmax_element` instead of Ncorr's ROI-aware helpers

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "Qt5")*


------
https://chatgpt.com/codex/tasks/task_e_68916ce307108320b42f565ffd6bd1fa